### PR TITLE
fix IPv6

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -86,6 +86,9 @@ Resources:
         - Description: Allow all outbound traffic (IPv4)
           IpProtocol: "-1"
           CidrIp: 0.0.0.0/0          
+        - Description: Allow all outbound traffic (IPv6)
+          IpProtocol: "-1"
+          CidrIpv6: ::/0
       Tags:
         - Key: StackName
           Value: !Sub ${AWS::StackName}


### PR DESCRIPTION
added egress rule to security group for IPv6 access

amazon-linux-extras does not work if IPv6 is set up in the VPC, but the egress security group rule does not allow IPv6 access.